### PR TITLE
Revert "dispatch events with ThreadPoolExecutor"

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/event/EventDispatcher.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/event/EventDispatcher.java
@@ -7,20 +7,12 @@
 
 package de.unistuttgart.informatik.fius.icge.event;
 
-import java.util.Deque;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.Executor;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
+import java.util.ArrayList;
 
 public class EventDispatcher {
     
-    private static Deque<Listening> _listenings = new ConcurrentLinkedDeque<>();
-    private static Executor _eventExecutor = new ThreadPoolExecutor(3, 5, 5, TimeUnit.MINUTES, new LinkedBlockingQueue<Runnable>());
+    private static ArrayList<Listening> _listenings = new ArrayList<>();
+    private static ArrayList<EventListener> _toRemove = new ArrayList<>();
     
     public static synchronized EventListener addListener(Class<?> listensFor, EventListener listener) {
         if (!Event.class.isAssignableFrom(listensFor)) throw new IllegalArgumentException();
@@ -29,22 +21,25 @@ public class EventDispatcher {
     }
     
     public static synchronized boolean removeListener(EventListener listener) {
-        return _listenings.remove(listener);
+        if (_listenings.stream().filter(entry -> entry.listener == listener).findFirst().isPresent()) {
+            _toRemove.add(listener);
+            return true;
+        } else
+            return false;
     }
     
     public static synchronized void raise(Event e) {
-        Runnable fn = () -> {
-            Set<EventListener> toRemove = new HashSet();
-            for (Listening entry : EventDispatcher._listenings) {
-                if (entry.listensFor.isAssignableFrom(e.getClass())) {
-                    if (!entry.listener.handle(e)) {
-                        toRemove.add(entry.listener);
-                    }
+        for (EventListener listener : _toRemove) {
+            _listenings.removeIf(entry -> entry.listener == listener);
+        }
+        _toRemove.clear();
+        for (Listening entry : _listenings) {
+            if (entry.listensFor.isAssignableFrom(e.getClass())) {
+                if (!entry.listener.handle(e)) {
+                    removeListener(entry.listener);
                 }
             }
-            EventDispatcher._listenings.removeIf(entry -> toRemove.contains(entry.listener));
-        };
-        _eventExecutor.execute(fn);
+        }
     }
     
     private static class Listening {


### PR DESCRIPTION
Doing dispatching asynchronously probably introduced hard-to-spot race conditions and
there was no performance problem.

This reverts commit aadb12342c051547aacf75560a3bf19f1029ed16.