### PR TITLE
simulation/Mario: Remove (currently) unused `coinCount`

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/GreedyEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/GreedyEntity.java
@@ -121,12 +121,14 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
     abstract boolean canCollectType(EntityType type);
     
     /**
-     * Informs the instance that a CollectableEntity has been collected.
+     * Informs the instance that a CollectableEntity has been collected. This method exists to be overriden.
      * 
      * @param type
      *            The type of collected entity
      */
-    abstract void collected(EntityType type);
+    void collected(EntityType type) {
+        // default implementation: do nothing
+    }
     
     /**
      * Checks whether an entity of the given type can be dropped by the instance, in general.
@@ -138,10 +140,12 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
     abstract boolean canDropType(EntityType type);
     
     /**
-     * Informs the instance that a CollectableEntity has been dropped.
+     * Informs the instance that a CollectableEntity has been dropped. This method exists to be overriden.
      * 
      * @param type
      *            The type of the dropped entity
      */
-    abstract void dropped(EntityType type);
+    void dropped(EntityType type) {
+        // default implementation: do nothing
+    }
 }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Mario.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Mario.java
@@ -9,8 +9,6 @@ package de.unistuttgart.informatik.fius.icge.simulation;
 
 public class Mario extends GreedyEntity {
     
-    private int coinCount = 0;
-    
     public Mario(Simulation sim) {
         super(sim, EntityType.MARIO);
     }
@@ -21,17 +19,8 @@ public class Mario extends GreedyEntity {
     }
     
     @Override
-    public void collected(EntityType type) {
-        this.coinCount++;
-    }
-    
-    @Override
     public boolean canDropType(EntityType type) {
         return type == EntityType.COIN;
     }
-    
-    @Override
-    public void dropped(EntityType type) {
-        this.coinCount--;
-    }
+
 }


### PR DESCRIPTION
I removed this now, since I'm planning to implement `Luigi` and then there would be two classes with this unused attribute.