### PR TITLE
fixup! simulation/MovableEntity: Attempt to fix a bug where the ui froze.

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
@@ -22,15 +22,11 @@ public abstract class MovableEntity extends Entity {
 
     protected MovableEntity(Simulation sim, EntityType type) {
         super(sim, type);
-    }
 
-    @Override
-    public void spawn(int column, int row, Direction direction) {
         EventDispatcher.addListener(SpawnEvent.class, ev -> {
             SpawnEvent se = (SpawnEvent) ev;
             if ((se.simulation == this.simulation()) && (se.entity == this)) {
                 this._positionStack.add(new MoveEvent(this.simulation(), this, se.row, se.column));
-                return this.alive();
             }
             return true;
         });
@@ -38,12 +34,9 @@ public abstract class MovableEntity extends Entity {
             MoveEvent me = (MoveEvent) ev;
             if ((me.simulation == this.simulation()) && (me.entity == this)) {
                 this._positionStack.add(me);
-                return this.alive();
             }
             return true;
         });
-
-        super.spawn(column, row, direction);
     }
 
     @Override


### PR DESCRIPTION
Supersedes #27.

Putting the `addListener()` call into `spawn()` was a bad idea.
When the entity was spawned multiple times (for example if it gets dropped or
`setTerritory()` was called inbetween, there were multiple listeners.
(Also, the `SpawnEvent` wasn't handled properly.)
The easiest thing for now is not to try to unregister the listeners.