### PR TITLE
Improve EntityState interface to not rely on hardcoded type checks in rendering and collision logic

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Coin.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Coin.java
@@ -16,6 +16,11 @@ public class Coin extends CollectableEntity {
         public Entity createEntity(Simulation sim) {
             return new Coin(sim);
         }
+
+        @Override
+        public boolean isSolid() {
+            return false;
+        }
     }
 
     public Coin(Simulation sim) {

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/GreedyEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/GreedyEntity.java
@@ -26,6 +26,11 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
         public GreedyEntityState(ArrayList<Entity> inventory) {
             this.inventory = inventory;
         }
+
+        @Override
+        public boolean isSolid() {
+            return false;
+        }
     }
 
     

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
@@ -115,7 +115,7 @@ public abstract class MovableEntity extends Entity {
         int newCol = column;
         int newRow = row;
         if (this.simulation().territory()
-                .containsWith(wall -> (wall.column == newCol) && (wall.row == newRow) && (wall.state.getClass() == WallState.class)))
+                .containsWith(wall -> (wall.column == newCol) && (wall.row == newRow) && wall.state.isSolid()))
             throw new IllegalMove();
         return new WorldObject(wob.state, column, row, 100, wob.direction);
     }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Wall.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Wall.java
@@ -15,6 +15,11 @@ public class Wall extends Entity {
         public Entity createEntity(Simulation sim) {
             return new Wall(sim);
         }
+
+        @Override
+        public boolean isSolid() {
+            return true;
+        }
     }
 
     public Wall(Simulation sim) {

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/territory/EntityState.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/territory/EntityState.java
@@ -10,7 +10,17 @@ package de.unistuttgart.informatik.fius.icge.territory;
 import de.unistuttgart.informatik.fius.icge.simulation.Entity;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
 
+/**
+ * Interface for managing basic entity state like sprite or solid status.
+ */
 public interface EntityState {
+
+    /**
+     * Creates a new Entity.
+     * 
+     * @param sim
+     * @return
+     */
     public Entity createEntity(Simulation sim);
 
     /**
@@ -22,7 +32,7 @@ public interface EntityState {
      */
     public default boolean isSolid() {
         return false;
-    };
+    }
 
     /**
      * Return the sprite id used to determine the sprite to render this Entity with.

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/territory/EntityState.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/territory/EntityState.java
@@ -16,9 +16,13 @@ public interface EntityState {
     /**
      * Checks wether the entity is considered  a solid entity.
      * 
+     * The default implementation always returns false.
+     * 
      * @return true if entity is solid
      */
-    public boolean isSolid();
+    public default boolean isSolid() {
+        return false;
+    };
 
     /**
      * Return the sprite id used to determine the sprite to render this Entity with.

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/territory/EntityState.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/territory/EntityState.java
@@ -12,4 +12,24 @@ import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
 
 public interface EntityState {
     public Entity createEntity(Simulation sim);
+
+    /**
+     * Checks wether the entity is considered  a solid entity.
+     * 
+     * @return true if entity is solid
+     */
+    public boolean isSolid();
+
+    /**
+     * Return the sprite id used to determine the sprite to render this Entity with.
+     * 
+     * @return this.getClass().getCanonicalName();
+     */
+    public default String spriteId() {
+        String spriteId = this.getClass().getCanonicalName();
+        if (spriteId == null) {
+            spriteId = this.getClass().getName();
+        }
+        return spriteId;
+    }
 }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/AnimatedImages.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/AnimatedImages.java
@@ -10,66 +10,244 @@ package de.unistuttgart.informatik.fius.icge.workbench.swing;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import de.unistuttgart.informatik.fius.icge.territory.EntityState;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject.Direction;
 
 public class AnimatedImages {
     
-    private final ArrayList<Entry> entries = new ArrayList<>();
+    private final Map<String, SpriteCollection> entries = new HashMap<>();
     
+    /**
+     * Set sprite(s) for Entity State class.
+     * 
+     * @param cls
+     * @param dir
+     * @param imgNames
+     */
     public void set(Class<? extends EntityState> cls, Direction dir, Collection<String> imgNames) {
-        ArrayList<BufferedImage> imgList = new ArrayList<>();
+        this.set(this.spriteIdFromClass(cls), dir, imgNames);
+    }
+    
+    /**
+     * Set sprite(s) for spriteId.
+     * 
+     * @param cls
+     * @param dir
+     * @param imgNames
+     */
+    public void set(String spriteId, Direction dir, Collection<String> imgNames) {
+        SpriteCollection coll = this.getCollectionById(spriteId, true);
+        
         for (String name : imgNames) {
-            imgList.add(Images.image(name));
+            coll.addImage(Images.image(name), dir);
         }
-        this.entries.add(new Entry(cls, dir, imgList));
-    }
+    }    
     
+    /**
+     * Set sprite(s) for Entity State class.
+     * 
+     * @param cls
+     * @param imgNames
+     */
     public void set(Class<? extends EntityState> cls, Collection<String> imgNames) {
-        for (Direction dir : Direction.values()) {
-            this.set(cls, dir, imgNames);
+        this.set(this.spriteIdFromClass(cls), imgNames);
+    }
+
+    /**
+     * Set sprite(s) for spriteId.
+     * 
+     * @param spriteId
+     * @param imgNames
+     */
+    public void set(String spriteId, Collection<String> imgNames) {
+        SpriteCollection coll = this.getCollectionById(spriteId, true);
+        
+        for (String name : imgNames) {
+            coll.addImage(Images.image(name));
         }
     }
     
+    /**
+     * Set sprite(s) for Entity State class.
+     * 
+     * @param cls
+     * @param dir
+     * @param imgName
+     */
     public void set(Class<? extends EntityState> cls, Direction dir, String imgName) {
-        ArrayList<String> list = new ArrayList<>();
-        list.add(imgName);
-        this.set(cls, dir, list);
+        this.set(this.spriteIdFromClass(cls), dir, imgName);
     }
     
+    /**
+     * Set sprite(s) for spriteId.
+     * 
+     * @param spriteId
+     * @param dir
+     * @param imgName
+     */
+    public void set(String spriteId, Direction dir, String imgName) {
+        SpriteCollection coll = this.getCollectionById(spriteId, true);
+        
+        coll.addImage(Images.image(imgName), dir);
+    }
+    
+    /**
+     * Set sprite(s) for Entity State class.
+     * 
+     * @param cls
+     * @param imgName
+     */
     public void set(Class<? extends EntityState> cls, String imgName) {
-        for (Direction dir : Direction.values()) {
-            this.set(cls, dir, imgName);
-        }
+        this.set(this.spriteIdFromClass(cls), imgName);
     }
     
+    /**
+     * Set sprite(s) for spriteId.
+     * 
+     * @param spriteId
+     * @param imgName
+     */
+    public void set(String spriteId, String imgName) {
+        SpriteCollection coll = this.getCollectionById(spriteId, true);
+        
+        coll.addImage(Images.image(imgName));
+    }
+    
+    /**
+     * Get Sprite for Entity State class.
+     * 
+     * @param cls
+     * @param dir
+     * @return
+     */
     public BufferedImage get(Class<? extends EntityState> cls, Direction dir) {
-        return this.get(cls, dir, 0);
+        return this.get(this.spriteIdFromClass(cls), dir, 0);
     }
     
+    /**
+     * Get Sprite for spriteId.
+     * 
+     * @param spriteId
+     * @param dir
+     * @return
+     */
+    public BufferedImage get(String spriteId, Direction dir) {
+        return this.get(spriteId, dir, 0);
+    }
+    
+    /**
+     * Get Sprite for Entity State class.
+     * 
+     * @param cls
+     * @param dir
+     * @param progress
+     * @return
+     */
     public BufferedImage get(Class<? extends EntityState> cls, Direction dir, float progress) {
-        if ((progress < 0) || (progress > 1)) throw new IllegalArgumentException();
-        for (Entry entry : this.entries) {
-            if ((entry.cls == cls) && (entry.dir == dir)) {
-                int size = entry.imgList.size();
-                int index = Math.min((int) (progress * size), size - 1);
-                return entry.imgList.get(index);
+        return this.get(this.spriteIdFromClass(cls), dir, progress);
+    }
+    
+    /**
+     * Get Sprite for spriteId.
+     * 
+     * @param spriteId
+     * @param dir
+     * @param progress
+     * @return
+     */
+    public BufferedImage get(String spriteId, Direction dir, float progress) {
+        if ((progress < 0) || (progress > 1)) throw new IllegalArgumentException("Progress out of bounds");
+        SpriteCollection sprites = this.getCollectionById(spriteId, false);
+        if (sprites == null) throw new IllegalArgumentException("Unknown sprite id");
+        List<BufferedImage> spriteList = sprites.getImages(dir);
+        int size = spriteList.size();
+        if (size <= 0) return null;
+        int index = Math.min((int) (progress * size), size - 1);
+        return spriteList.get(index);
+    }
+
+    /**
+     * Get the sprite collection with the given spriteId
+     * 
+     * @param spriteId
+     * @param createIfNull if true and collection is null create a new SpriteCollection
+     * @return
+     */
+    private SpriteCollection getCollectionById(String spriteId, boolean createIfNull) {
+        SpriteCollection coll = this.entries.get(spriteId);
+        if (createIfNull && coll == null) {
+            coll = new SpriteCollection(spriteId);
+            this.entries.put(spriteId, coll);
+        }
+        return coll;
+    }
+
+    /**
+     * Generate standard spriteId for Entity State class
+     * 
+     * @param cls
+     * @return
+     */
+    private String spriteIdFromClass(Class<? extends EntityState> cls) {
+        String spriteId = cls.getCanonicalName();
+        if (spriteId == null) {
+            spriteId = cls.getName();
+        }
+        return spriteId;
+    }
+    
+    private static class SpriteCollection {
+        
+        public final String spriteId;
+        private List<BufferedImage> imagesNorth;
+        private List<BufferedImage> imagesEast;
+        private List<BufferedImage> imagesSouth;
+        private List<BufferedImage> imagesWest;
+        
+        public SpriteCollection(String spriteId) {
+            this.spriteId = spriteId;
+            this.imagesNorth = new ArrayList<>(2);
+            this.imagesEast = new ArrayList<>(2);
+            this.imagesSouth = new ArrayList<>(2);
+            this.imagesWest = new ArrayList<>(2);
+        }
+
+        public void addImage(BufferedImage image) {
+            for (Direction dir : Direction.values()) {
+                this.addImage(image, dir);
             }
         }
-        return null;
-    }
-    
-    private static class Entry {
-        
-        public final Class<? extends EntityState> cls;
-        public final Direction dir;
-        public final ArrayList<BufferedImage> imgList;
-        
-        public Entry(Class<? extends EntityState> cls, Direction dir, ArrayList<BufferedImage> imgList) {
-            this.cls = cls;
-            this.dir = dir;
-            this.imgList = imgList;
+
+        public void addImage(BufferedImage image, Direction dir) {
+            switch (dir) {
+                case NORTH: this.imagesNorth.add(image);
+                    break;
+                case EAST: this.imagesEast.add(image);
+                    break;
+                case SOUTH: this.imagesSouth.add(image);
+                    break;
+                case WEST: this.imagesWest.add(image);
+                    break;
+                default: this.imagesEast.add(image);
+            }
+        }
+
+        public List<BufferedImage> getImages() {
+            return this.getImages(Direction.EAST);
+        }
+
+        public List<BufferedImage> getImages(Direction dir) {
+            switch (dir) {
+                case NORTH: return this.imagesNorth;
+                case EAST: return this.imagesEast;
+                case SOUTH: return this.imagesSouth;
+                case WEST: return this.imagesWest;
+                default: return this.imagesEast;
+            }
         }
     }
 }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/AnimationInterpreter.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/AnimationInterpreter.java
@@ -35,14 +35,14 @@ public class AnimationInterpreter {
         if (!animated.territory().contains(wob)) throw new IllegalArgumentException();
         this._column = wob.column;
         this._row = wob.row;
-        this._unanimatedImage = this._image = _noneAnimations.get(wob.state.getClass(), wob.direction);
+        this._unanimatedImage = this._image = _noneAnimations.get(wob.state.spriteId(), wob.direction);
         Animation animation = animated.animation(wob);
         if (animation != null && currentTick < animation.end) {
             if ((currentTick < animation.begin)) throw new IllegalArgumentException();
             this._inAnimation = true;
             float undone = (animation.end - currentTick) / (float) (animation.end - animation.begin);
             float progress = 1 - undone;
-            this._image = _animatedImages.get(animation.type).get(wob.state.getClass(), wob.direction, progress);
+            this._image = _animatedImages.get(animation.type).get(wob.state.spriteId(), wob.direction, progress);
             if (this._image != null) {
                 if (animation.type == AnimationType.Move) {
                     switch (wob.direction) {


### PR DESCRIPTION
The changes are fully internal and should not affect any tasks or solutions.
These changes allow for example Displaying different sprites depending on EntityState or new solid Entities.