### PR TITLE
javadoc, better delayTicks handling, use isSolid in spawn checks

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/animations/SimulationAnimator.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/animations/SimulationAnimator.java
@@ -64,7 +64,10 @@ public class SimulationAnimator {
             if (se instanceof MovableEntityEvent) {
                 MovableEntityEvent mee = (MovableEntityEvent) se;
                 int begin = mee.simulation.tickCount();
-                int end = begin + sima._delay;
+                int end = mee.entity.getMoveEndTick();
+                if (end < begin) {
+                    end = begin + 1;
+                }
                 WorldObject wob = mee.entity.worldObject();
                 Animation anim = new Animation(begin, end, animationType(mee));
                 nextAnimated.setAnimation(wob, anim);

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Coin.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Coin.java
@@ -9,6 +9,9 @@ package de.unistuttgart.informatik.fius.icge.simulation;
 
 import de.unistuttgart.informatik.fius.icge.territory.EntityState;
 
+/**
+ * Coin collectable entity
+ */
 public class Coin extends CollectableEntity {
 
     public static class CoinState implements EntityState {

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/CollectableEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/CollectableEntity.java
@@ -10,7 +10,7 @@ package de.unistuttgart.informatik.fius.icge.simulation;
 import de.unistuttgart.informatik.fius.icge.territory.EntityState;
 
 /**
- * A entity which is collectable.
+ * Base class for collectable entities
  * 
  * @author haslersn, neumantm
  */
@@ -19,5 +19,10 @@ public abstract class CollectableEntity extends Entity {
         super(sim);
     }
     
+    /**
+     * Returns the space or weight requirements of this collectable entity
+     * 
+     * @return
+     */
     public abstract int requiredSpace();
 }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Entity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Entity.java
@@ -18,29 +18,58 @@ import de.unistuttgart.informatik.fius.icge.territory.EntityState;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject.Direction;
 
+/**
+ * Base class for all entities
+ */
 public abstract class Entity {
 
     private final Simulation _sim;
     private int _delayTicks = 25;
-    private int _lastMoveTick = Integer.MIN_VALUE;
+    private int _blockedUntilTick = Integer.MIN_VALUE;
 
+    /**
+     * Create a new entity in the given simulation
+     * 
+     * @param sim
+     */
     protected Entity(Simulation sim) {
         this._sim = sim;
         this._delayTicks = this.getStandardDelayTicks();
     }
 
+    /**
+     * Get the EntityState object that manages this entity's state
+     * 
+     * @return
+     */
     public abstract EntityState state();
 
+    /**
+     * Get the Simulation object this entity is a part of
+     * 
+     * @return
+     */
     public final Simulation simulation() {
         return this._sim;
     }
 
+    /**
+     * Get the current WorldObject of this entity
+     * 
+     * @return
+     * @throws EntityNotAlive only spwaned entities have a world object
+     */
     public final WorldObject worldObject() throws EntityNotAlive {
         WorldObject result = this.simulation().worldObject(this);
         if (result == null) throw new EntityNotAlive();
         return result;
     }
 
+    /**
+     * Get the alive state of this entity
+     * 
+     * @return true iff the entity is spawned in its simulation
+     */
     public final boolean alive() {
         return this.simulation().entities().contains(this);
     }
@@ -55,8 +84,18 @@ public abstract class Entity {
         return this.worldObject().row;
     }
 
+    @Override
     public String toString() {
         return "<Entity " + this.getClass().getSimpleName() + ">";
+    }
+
+    /**
+     * Get the tick the entity waits for for its last move to complete
+     *  
+     * @return
+     */
+    public int getMoveEndTick() {
+        return this._blockedUntilTick;
     }
 
     /**
@@ -95,19 +134,49 @@ public abstract class Entity {
         this.simulation().setWorldObject(this, wobNew, new TeleportEvent(this._sim, this, wobNew));
     }
 
+    /**
+     * Get the z value of this entity used to determine the drawing order of 
+     * entities in the same cell.
+     * 
+     * Entities with higher z are drawn above entities with lower z
+     *   
+     * @return
+     */
     protected float getZ() {
         return 0;
     }
 
+    /**
+     * Get the standard delay ticks for actions of this entity
+     * 
+     * @return
+     */
     protected int getStandardDelayTicks() {
         return 25;
     }
 
-    public void spawn(int column, int row) throws EntityAlreadyAlive, CellBlockedByWall {
+    /**
+     * Spawn this entity at the given coordinates facing east
+     * 
+     * @param column
+     * @param row
+     * @throws EntityAlreadyAlive the entity is already spawned
+     * @throws CellBlockedBySolidEntity the spawn position is blocked by a solid entity
+     */
+    public void spawn(int column, int row) throws EntityAlreadyAlive, CellBlockedBySolidEntity {
         this.spawn(column, row, Direction.EAST);
     }
 
-    public void spawn(int column, int row, Direction direction) throws EntityAlreadyAlive, CellBlockedByWall {
+    /**
+     * Spawn this entity at the given coordinates with the given direction
+     * 
+     * @param column
+     * @param row
+     * @param direction
+     * @throws EntityAlreadyAlive the entity is already spawned
+     * @throws CellBlockedBySolidEntity the spawn position is blocked by a solid entity
+     */
+    public void spawn(int column, int row, Direction direction) throws EntityAlreadyAlive, CellBlockedBySolidEntity {
         this.spawnInternal(column, row, direction, false);
     }
 
@@ -125,6 +194,11 @@ public abstract class Entity {
         this.spawnInternal(column, row, direction, true);
     }
 
+    /**
+     * Despawn this entity
+     * 
+     * @throws EntityNotAlive the entity is not spawned
+     */
     @InspectionMethod
     public final void despawn() throws EntityNotAlive {
         this.despawnInternal(false);
@@ -137,12 +211,24 @@ public abstract class Entity {
         despawnInternal(true);
     }
 
-    /** delay is in simulation ticks */
+    /**
+     * set the delay in ticks for all actions performed by this entity in the future
+     * 
+     * The delay controls how many ticks the entity is in a blocked/busy state 
+     * after performing an action
+     * 
+     * @param delay
+     */
     public void setDelay(int delay) {
         this._delayTicks = delay;
     }
 
-    /** reset delay to standard */
+    /** 
+     * reset delay to standard standard amount of ticks 
+     * 
+     * The delay controls how many ticks the entity is in a blocked/busy state 
+     * after performing an action
+     */
     public void resetDelay() {
         this._delayTicks = this.getStandardDelayTicks();
     }
@@ -161,30 +247,72 @@ public abstract class Entity {
         });
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(boolean message) {
         this.print(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(byte message) {
         this.print(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(short message) {
         this.print(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(int message) {
         this.print(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(long message) {
         this.print(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(float message) {
         this.print(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void print(double message) {
         this.print(String.valueOf(message));
     }
@@ -201,40 +329,99 @@ public abstract class Entity {
         this.print(message + "\n");
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(boolean message) {
         this.printLn(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(byte message) {
         this.printLn(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(short message) {
         this.printLn(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(int message) {
         this.printLn(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(long message) {
         this.printLn(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(float message) {
         this.printLn(String.valueOf(message));
     }
 
+    /**
+     * Generates a Message Event that gets written to the log Panel.
+     * Adds a newline Character to the end of the message.
+     * 
+     * @param message
+     *            The message to print
+     */
     public void printLn(double message) {
         this.printLn(String.valueOf(message));
     }
 
     // protected
 
+    /**
+     * Internal spawn logic for entities
+     * 
+     * @param column
+     * @param row
+     * @param direction
+     * @param force if true perform spawn with delay set to 0
+     * @throws EntityAlreadyAlive
+     * @throws CellBlockedBySolidEntity
+     */
     protected void spawnInternal(int column, int row, Direction direction, boolean force)
-            throws EntityAlreadyAlive, CellBlockedByWall {
+            throws EntityAlreadyAlive, CellBlockedBySolidEntity {
         for (Entity e : this.simulation().entitiesWith(row, column)) {
-            if (e instanceof Wall) throw new CellBlockedByWall();
+            if (e.state().isSolid()) throw new CellBlockedBySolidEntity();
         }
 
         WorldObject wob = new WorldObject(this.state(), column, row, getZ(), direction);
@@ -245,6 +432,11 @@ public abstract class Entity {
         }, force ? 0 : this._delayTicks);
     }
 
+    /**
+     * Internal despawn logic for entities
+     * 
+     * @param force if true perform despawn with delay set to 0
+     */
     protected void despawnInternal(boolean force) {
         SimulationEvent ev = new DespawnEvent(this.simulation(), this);
         this.delayed(() -> {
@@ -254,7 +446,10 @@ public abstract class Entity {
     }
 
     /**
-     * Runs the given runnable after the delay period or immediately
+     * Runs the given runnable after this entity is free
+     * 
+     * If (this.simulation().tickCount() >= this._blockedUntilTick)
+     * the runnable is executed immediately
      * 
      * @param fn
      *            The runnable
@@ -264,16 +459,20 @@ public abstract class Entity {
     }
 
     /**
-     * Runs the given runnable after the delay period or immediately
+     * Runs the given runnable after this entity is free
+     * 
+     * If (this.simulation().tickCount() >= this._blockedUntilTick)
+     * the runnable is executed immediately
      * 
      * @param fn
      *            The runnable
      * @param delay
-     *            Delay in Ticks after which fn is run. Use 0 or negative numbers to instantly run fn
+     *            Delay in Ticks after which the entity is considered busy after executing the runnable.
+     *            Use 0 or negative numbers to instantly run fn regardless of busy state.
      */
     protected synchronized void delayed(Runnable fn, int delay) {
         if (delay > 0) {
-            int thisMoveTick = this._lastMoveTick + delay;
+            int thisMoveTick = this._blockedUntilTick;
             if (this.simulation().tickCount() < thisMoveTick) {
                 Semaphore sem = new Semaphore(0);
                 EventDispatcher.addListener(TickEvent.class, ev -> {
@@ -288,8 +487,8 @@ public abstract class Entity {
             }
         }
         synchronized (this.simulation()) {
+            this._blockedUntilTick = this.simulation().tickCount() + delay;
             fn.run();
-            this._lastMoveTick = this.simulation().tickCount();
         }
     }
 
@@ -299,7 +498,7 @@ public abstract class Entity {
         private static final long serialVersionUID = -21686971924440414L;
     }
 
-    public static class CellBlockedByWall extends RuntimeException {
+    public static class CellBlockedBySolidEntity extends RuntimeException {
         private static final long serialVersionUID = -7878416133186725145L;
     }
 
@@ -309,6 +508,9 @@ public abstract class Entity {
 
     // Events:
 
+    /**
+     * Base class for all entity related events
+     */
     public static abstract class EntityEvent extends SimulationEvent {
 
         public final Entity entity;
@@ -319,6 +521,9 @@ public abstract class Entity {
         }
     }
 
+    /**
+     * Event containing a message from an entity
+     */
     public static class MessageEvent extends EntityEvent {
 
         public final String message;
@@ -330,6 +535,9 @@ public abstract class Entity {
 
     }
 
+    /**
+     * Spawn event recording spawn coordinates of the entity
+     */
     public static class SpawnEvent extends EntityEvent {
 
         public final int row;
@@ -348,6 +556,9 @@ public abstract class Entity {
         }
     }
 
+    /**
+     * Teleport event recording target coordinates of this teleport
+     */
     public static class TeleportEvent extends EntityEvent {
         public final int row;
         public final int column;
@@ -365,6 +576,9 @@ public abstract class Entity {
         }
     }
 
+    /**
+     * Despawn event
+     */
     public static class DespawnEvent extends EntityEvent {
         public DespawnEvent(Simulation sim, Entity entity) {
             super(sim, entity);

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/EntityCollector.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/EntityCollector.java
@@ -23,7 +23,6 @@ public interface EntityCollector {
      *            The class of entity to collect
      * @return Whether this entity can currently collect such an entity.
      * @throws EntityNotAlive
-     *             When this entity is not alive.
      */
     public boolean canCollect(Class<? extends Entity> cls) throws EntityNotAlive;
 
@@ -32,18 +31,55 @@ public interface EntityCollector {
      * 
      * @return Whether this entity can currently collect.
      * @throws EntityNotAlive
-     *             When this entity is not alive.
      */
     public boolean canCollect() throws EntityNotAlive;
 
+    /**
+     * Collect a collectable entity by class
+     * 
+     * @param cls class of a collectable entity
+     * @throws CanNotCollectException 
+     *             this entity collector can not collect this collectable entity
+     * @throws EntityNotAlive
+     */
     public void collect(Class<? extends Entity> cls) throws CanNotCollectException, EntityNotAlive;
 
+    /**
+     * Collect a collectable entity with the same coordinates as this entity collector
+     * 
+     * @throws CanNotCollectException
+     *             this entity collector can not collect any entity with this coordinates
+     * @throws EntityNotAlive
+     */
     public void collect() throws CanNotCollectException, EntityNotAlive;
 
+    /**
+     * Return if this entity collector can drop an entity of the given class
+     * 
+     * @param cls the class of the entity to drop
+     * @return 
+     *             true iff the entity collector can drop entities of this class 
+     *             and currently holds an entity of this class
+     * @throws EntityNotAlive
+     */
     public boolean canDrop(Class<? extends Entity> cls) throws EntityNotAlive;
 
+    /**
+     * Drop an entity of the given class
+     *  
+     * @param cls
+     * @throws CanNotDropException 
+     *             if canDrop(cls) == false
+     * @throws EntityNotAlive 
+     */
     public void drop(Class<? extends Entity> cls) throws CanNotDropException, EntityNotAlive;
 
+    /**
+     * Try to collect a collectable entity with the given class
+     * 
+     * @param cls
+     * @return true iff entity was collected
+     */
     default public boolean tryCollect(Class<? extends Entity> cls) {
         try {
             this.collect(cls);
@@ -53,6 +89,11 @@ public interface EntityCollector {
         }
     }
 
+    /**
+     * Try to collect a collectable entity with the same coordinates as this entity collector
+     * 
+     * @return true iff entity was collected
+     */
     default public boolean tryCollect() {
         try {
             this.collect();
@@ -62,6 +103,12 @@ public interface EntityCollector {
         }
     }
 
+    /**
+     * Try to drop a collectable entity with the given class
+     * 
+     * @param cls
+     * @return true iff entity was dropped
+     */
     default public boolean tryDrop(Class<? extends Entity> cls) {
         try {
             this.drop(cls);

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/GreedyEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/GreedyEntity.java
@@ -20,6 +20,9 @@ import de.unistuttgart.informatik.fius.icge.territory.WorldObject;
  */
 public abstract class GreedyEntity extends MovableEntity implements EntityCollector {
 
+    /**
+     * Entity State for greedy entitys managing basic inventory
+     */
     public abstract static class GreedyEntityState implements EntityState {
         protected final ArrayList<Entity> inventory;
 
@@ -33,7 +36,7 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
         }
     }
 
-    
+    /** internal inventory of a greedy entity */
     @InspectionAttribute(readOnly = true, name = "Inventory")
     protected final ArrayList<Entity> _inventory;
 
@@ -42,18 +45,53 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
         this._inventory = inventory;
     }
     
+    /**
+     * Internal test if an entity can be collected by this greedy entity
+     * 
+     * @param ent entity to test
+     * @return
+     * @throws EntityNotAlive
+     */
     protected boolean canCollectEntity(Entity ent) throws EntityNotAlive {
         return (ent instanceof CollectableEntity) && canCollectType(ent.getClass()) && ent.worldObject().isSamePos(this.worldObject());
     }
 
+    /**
+     * Internal test if an entity can be dropped by this greedy entity
+     * 
+     * @param ent entity to test
+     * @return
+     * @throws EntityNotAlive
+     */
     protected boolean canDropEntity(Entity ent) throws EntityNotAlive {
         return canDropType(ent.getClass());
     }
 
+    /**
+     * Check if this greedy entity can collect entities of the given class
+     * 
+     * @param cls
+     * @return true iff class can be collected
+     */
     protected abstract boolean canCollectType(Class<? extends Entity> cls);
 
+
+    /**
+     * Check if this greedy entity can drop entities of the given class
+     * 
+     * @param cls
+     * @return true iff class can be dropped
+     */
     protected abstract boolean canDropType(Class<? extends Entity> cls);
     
+    /**
+     * Internal entity collection logic of greedy entity
+     * 
+     * This method handles despawn of the collected entity and inventory management
+     * 
+     * @param ent
+     * @throws EntityNotAlive
+     */
     private void collectEntity(CollectableEntity ent) throws EntityNotAlive {
         ent.despawn();
         this._inventory.add(ent);
@@ -140,6 +178,8 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
     /**
      * Informs the instance that a CollectableEntity has been collected. This method exists to be overriden.
      * 
+     * The invenory management is already done in greedy entity!
+     * 
      * @param ent
      *            The entity that has been collected
      */
@@ -149,6 +189,8 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
     
     /**
      * Informs the instance that a CollectableEntity has been dropped. This method exists to be overriden.
+     * 
+     * The invenory management is already done in greedy entity!
      * 
      * @param ent
      *            The dropped entity

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
@@ -12,11 +12,13 @@ import java.util.Deque;
 
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation.SimulationEvent;
-import de.unistuttgart.informatik.fius.icge.simulation.Wall.WallState;
 import de.unistuttgart.informatik.fius.icge.simulation.inspection.InspectionMethod;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject.Direction;
 
+/**
+ * Base class for movable entities
+ */
 public abstract class MovableEntity extends Entity {
 
     private final Deque<MoveEvent> _positionStack = new ArrayDeque<>(100);
@@ -45,6 +47,12 @@ public abstract class MovableEntity extends Entity {
         return 100;
     }
 
+    /**
+     * Move this entity one field in the current direction
+     * 
+     * @throws IllegalMove the field is occupied by a solid entity
+     * @throws EntityNotAlive the entity is not spawned or already despawned
+     */
     @InspectionMethod
     public void move() throws IllegalMove, EntityNotAlive {
         this.delayed(() -> {
@@ -54,6 +62,11 @@ public abstract class MovableEntity extends Entity {
         });
     }
 
+    /**
+     * Check if the entity can move one field in the current direction
+     * 
+     * @return true iff the entity can move
+     */
     public boolean canMove() {
         try {
             this.wobAfterMove();
@@ -63,6 +76,11 @@ public abstract class MovableEntity extends Entity {
         }
     }
 
+    /**
+     * Try to move this entity one field in the current direction
+     * 
+     * @return true iff the entity has moved
+     */
     public boolean tryMove() {
         try {
             this.move();
@@ -72,6 +90,11 @@ public abstract class MovableEntity extends Entity {
         }
     }
 
+    /**
+     * Turn this entity 90° counterclockwise (meaning 1 step to this entity's left)
+     * 
+     * @throws EntityNotAlive the entity is not spawned or already despawned 
+     */
     @InspectionMethod
     public void turnLeft() throws EntityNotAlive {
         SimulationEvent ev = new TurnLeftEvent(this.simulation(), this);
@@ -80,20 +103,48 @@ public abstract class MovableEntity extends Entity {
         });
     }
 
+    /**
+     * Get the first position of this entity as a MoveEvent
+     * 
+     * The first position is the entity's spawn position
+     * 
+     * @return
+     */
     public MoveEvent firstPosition() {
         return this._positionStack.peekFirst();
     }
 
+
+    /**
+     * Get the last known position of this entity as a MoveEvent
+     * 
+     * @return
+     */
     public MoveEvent lastPosition() {
         return this._positionStack.peekLast();
     }
 
+    /**
+     * Get the whole position history of this entity as an Iterable for use in a for loop
+     * 
+     * The iterable starts with this.firstPosition() and ends with this.lastPosition
+     *  
+     * @return
+     */
     public Iterable<MoveEvent> positionHistory() {
         return () -> this._positionStack.iterator();
     }
 
     // private
 
+    /**
+     * Create a new worldobject with the calculated coordinates of one field in 
+     * front of this entity
+     *  
+     * @return
+     * @throws IllegalMove
+     * @throws EntityNotAlive
+     */
     private WorldObject wobAfterMove() throws IllegalMove, EntityNotAlive {
         WorldObject wob = this.worldObject();
         int column = wob.column;
@@ -120,6 +171,12 @@ public abstract class MovableEntity extends Entity {
         return new WorldObject(wob.state, column, row, 100, wob.direction);
     }
 
+    /**
+     * Create a new WorldObject with the direction after a left turn
+     * 
+     * @return
+     * @throws EntityNotAlive
+     */
     private WorldObject wobAfterTurnLeft() throws EntityNotAlive {
         WorldObject wob = this.worldObject();
         Direction dir = wob.direction;
@@ -150,12 +207,18 @@ public abstract class MovableEntity extends Entity {
 
     // Events
 
+    /**
+     * Base class for events from movable entities
+     */
     public static abstract class MovableEntityEvent extends EntityEvent {
         MovableEntityEvent(Simulation sim, MovableEntity entity) {
             super(sim, entity);
         }
     }
 
+    /**
+     * Move event recording the target coordinates of the movable entity
+     */
     public static class MoveEvent extends MovableEntityEvent {
 
         public final int column;
@@ -174,6 +237,9 @@ public abstract class MovableEntity extends Entity {
         }
     }
 
+    /**
+     * Event for left turns of an entity
+     */
     public static class TurnLeftEvent extends MovableEntityEvent {
         TurnLeftEvent(Simulation sim, MovableEntity entity) {
             super(sim, entity);

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Wall.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Wall.java
@@ -10,6 +10,9 @@ package de.unistuttgart.informatik.fius.icge.simulation;
 import de.unistuttgart.informatik.fius.icge.territory.EntityState;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject.Direction;
 
+/**
+ * Solid entity with the sprite of a wall
+ */
 public class Wall extends Entity {
     public static class WallState implements EntityState {
         public Entity createEntity(Simulation sim) {
@@ -35,7 +38,7 @@ public class Wall extends Entity {
      * @see de.unistuttgart.informatik.fius.icge.simulation.Entity#spawn(int, int, de.unistuttgart.informatik.fius.icge.territory.WorldObject.Direction)
      */
     @Override
-    public void spawn(int column, int row, Direction direction) throws EntityAlreadyAlive, CellBlockedByWall {
+    public void spawn(int column, int row, Direction direction) throws EntityAlreadyAlive, CellBlockedBySolidEntity {
         if (!this.simulation().entitiesWith(row, column).isEmpty()) {
             throw new CellNotEmpty();
         }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/tools/AbstractSpawnEntityTool.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/tools/AbstractSpawnEntityTool.java
@@ -7,7 +7,7 @@
 
 package de.unistuttgart.informatik.fius.icge.workbench.tools;
 
-import de.unistuttgart.informatik.fius.icge.simulation.Entity.CellBlockedByWall;
+import de.unistuttgart.informatik.fius.icge.simulation.Entity.CellBlockedBySolidEntity;
 import de.unistuttgart.informatik.fius.icge.simulation.Entity;
 import de.unistuttgart.informatik.fius.icge.simulation.Mario;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
@@ -41,7 +41,7 @@ public abstract class AbstractSpawnEntityTool extends AbstractTool {
     public void apply(Simulation sim, int row, int column) {
         try {
             entityToSpawn(sim).forceSpawn(column, row);
-        } catch(CellBlockedByWall e) {
+        } catch(CellBlockedBySolidEntity e) {
             // intentionally do nothing since this was attempted via the GUI
         }
     }


### PR DESCRIPTION
delay now sets endTick instead of calculating it from startTick + current delay as delay is flexible
animations use moveEndTick of entity to calculate animation state

used isSolid method of entity state to check if spawn is allowed. renamed exception accordingly