### PR TITLE
workbench/swing/SimPanel: [bugfix] #52

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/SimPanel.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/SimPanel.java
@@ -166,9 +166,11 @@ public class SimPanel extends JPanel {
     }
 
     private void drawMouseOverlay() {
+        if (!this._mouseInside) return;
         int startRow = this._startRow;
         int startCol = this._startCol;
-        if (!this._toolHandler.isCurrentToolArea()) {
+        // When the current tool is not an area tool, we don't want to overlay an area
+        if (!this._toolHandler.currentToolIsAreaTool()) {
             startRow = this._endRow;
             startCol = this._endCol;
         }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/tools/ToolHandler.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/tools/ToolHandler.java
@@ -113,7 +113,7 @@ public class ToolHandler {
     /**
      * @return Whether the current tool is a area tool.
      */
-    public boolean isCurrentToolArea() {
+    public boolean currentToolIsAreaTool() {
         Tool t = this.tools.get(this.currentTool);
         return (t instanceof AreaTool);
     }


### PR DESCRIPTION
Fix that cells stay focused (overlayed) after the curser left the SimPanel.

Closes #52