### PR TITLE
simulation: [bugfix] #73

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Simulation.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Simulation.java
@@ -49,8 +49,12 @@ public class Simulation {
      */
     public Simulation(Simulation sim) {
         synchronized (sim) {
-            this._running = sim._running;
             this.init(sim._tty);
+            this._running = sim._running;
+            this._tickCount = sim._tickCount;
+            if (this._running) {
+                this.startTimer();
+            }
         }
     }
 


### PR DESCRIPTION
No copying a running `Simulation` should yield an actually running `Simulation`.

Closes #73