### PR TITLE
Simulation: [bugfix] deadlock if `pause()` is called during simulation tick

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Simulation.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Simulation.java
@@ -332,10 +332,12 @@ public class Simulation {
 
             @Override
             public void run() {
-                if (!this.sem.tryAcquire()) {
-                    this.cancel();
+                synchronized (Simulation.this) {
+                    if (!this.sem.tryAcquire()) {
+                        this.cancel();
+                    }
+                    Simulation.this.tick(this.sem::release);
                 }
-                Simulation.this.tick(this.sem::release);
             }
         };
         new Timer().schedule(this._timerTask, this._tickMillis, this._tickMillis);


### PR DESCRIPTION
In the `Simulation`s tick code, a semaphore is acquired and then the `tick()` method is called.
There was a deadlock if the `pause()` method was called from another thread after the semaphore
was acquired but before the `tick()` method is called. This was due to the fact that `tick()`
as well as `pause()` are synchronized, so `tick()` waits for `pause()` to finish, but `pause()`
tries to acquire the semaphore as well (in order to cancel the `TimerTask` -- the `TimerTask,
once run for the next time, finds out that it can't lock the semaphore and terminates itself).

NOTE: With this fix, we don't use the synchronization property of the mentioned semaphore. It's
now just used as a mutable Boolean which, once false (i.e. it can't be acquired anymore) causes
the `TimerTask` to terminate itself. We could therefore replace it by something else in the
future, avoiding the synchronization overhead.