### PR TITLE
treewide: Introduced the so-called `EventHandler`s

### DIFF
--- a/src/main/java/de/unistuttgart/informatik/fius/icge/event/EventDispatcher.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/event/EventDispatcher.java
@@ -7,35 +7,78 @@
 
 package de.unistuttgart.informatik.fius.icge.event;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 
+/**
+ * `EventDispatcher` is a class with only static methods where `EventHandler`s can be registered. If an `EventHandler` is
+ * registered, every `Event` that is raised via the `EventDispatcher.raise()` method is forwarded to the `handle()` method of
+ * the registered `EventHandler`. There can be arbitrarily many `EventHandler`s registered at the same time. The order in which
+ * raised `Event`s are forwarded to them is unspecified.
+ */
 public class EventDispatcher {
 
-    private static ArrayList<Listening> _listenings = new ArrayList<>();
+    private static ArrayList<WeakReference<EventHandler>> _handlerRefs = new ArrayList<>();
     private static ArrayDeque<Runnable> _afterwards = new ArrayDeque<>();
     private static int _raiseRecursionDepth = 0;
 
-    public static synchronized EventListener addListener(Class<?> listensFor, EventListener listener) {
-        if (!Event.class.isAssignableFrom(listensFor)) throw new IllegalArgumentException();
-        _listenings.add(new Listening(listensFor, listener));
-        return listener;
+    /**
+     * Registers an `EventHandler` to the `EventDispatcher`. For details, see the JavaDoc of `EventDispatcher`
+     * 
+     * @param handler
+     *            The `EventHandler` to register
+     * @return true if the specified `EventHandler` wasn't already registered, false if it was already registered
+     */
+    public static synchronized boolean registerHandler(EventHandler handler) {
+        for (WeakReference<EventHandler> ref : _handlerRefs) {
+            if (ref.get() == handler) return false;
+        }
+        _handlerRefs.add(new WeakReference<>(handler));
+        return true;
     }
 
-    public static synchronized boolean removeListener(EventListener listener) {
-        return _listenings.removeIf(entry -> entry.listener == listener);
+    /**
+     * Deregisters an `EventHandler` to the `EventDispatcher`. For details, see to JavaDoc of `EventDispatcher`.
+     * 
+     * @param handler
+     *            The `EventHandler` to deregister
+     * @return true if the specified `EventHandler` was registered, false if it wasn't
+     */
+    public static synchronized boolean deregisterHandler(EventHandler handler) {
+        return _handlerRefs.removeIf(ref -> {
+            EventHandler candidate = ref.get();
+            return candidate == null || candidate == handler;
+        });
     }
 
+    /**
+     * Raises an event and afterwards runs the tasks that have been scheduled via the `afterwards()` method. This method mustn't
+     * be called while another event is handled in the same thread.
+     * 
+     * NOTE: If you want to raise an event (or perform some action that would raise an event) during the handling of an event,
+     * consider to call `EventDispatcher.afterwards()`.
+     * 
+     * @param e
+     *            The event to raise
+     */
     public static synchronized void raise(Event e) throws RaiseAlreadyActive {
         EventDispatcher.raise(e, () -> {});
     }
 
     /**
-     * Raises an event, then runs an `afterTask` and finally runs the
+     * Raises an event, then runs an `afterTask` and finally runs the tasks that have been scheduled via the `afterwards()`
+     * method. This method mustn't be called while another event is handled in the same thread.
+     * 
+     * NOTE: If you want to raise an event (or perform some action that would raise an event) during the handling of an event,
+     * consider to call `EventDispatcher.afterwards()`.
      * 
      * @param e
+     *            The event to raise
      * @param afterTask
+     *            The task to run after the handling of that event
      * @throws RaiseAlreadyActive
+     *             if another event is currently handled in the same thread
      */
     public static synchronized void raise(Event e, Runnable afterTask) throws RaiseAlreadyActive {
         if (EventDispatcher._raiseRecursionDepth != 0) {
@@ -45,11 +88,12 @@ public class EventDispatcher {
         // actual event hadling
         ++EventDispatcher._raiseRecursionDepth;
         try {
-            for (Listening entry : new ArrayList<>(_listenings)) { // new list cause it might get modified concurrently
-                if (entry.listensFor.isAssignableFrom(e.getClass())) {
-                    if (!entry.listener.handle(e)) {
-                        removeListener(entry.listener);
-                    }
+            for (WeakReference<EventHandler> ref : new ArrayList<>(_handlerRefs)) {
+                EventHandler handler = ref.get();
+                if (handler == null) {
+                    _handlerRefs.remove(ref);
+                } else {
+                    handler.raise(e);
                 }
             }
         } finally {
@@ -64,10 +108,10 @@ public class EventDispatcher {
     }
 
     /**
-     * Schedules a runnable that is run synchronously after the handling of the next event.
-     * If an `EventHandler.raise()` call is currently active (i.e. an event is currently handled)
-     * AND this method is called from the same thread where that event is raised (and handled) in,
-     * the runnable is run after the handling of that event.
+     * Schedules a `Runnable` that is run synchronously after the handling of the currently handled event. This method must be
+     * called during the handling of an event (i.e. during a call of `EventHandler.raise()`) and must be called from the thread
+     * in which that event is raised (and handled). If multiple `Runnable`s are scheduled this way, they are run in FIFO order
+     * (first in, first out).
      * 
      * @param rn
      *            The runnable to schedule
@@ -80,22 +124,18 @@ public class EventDispatcher {
         _afterwards.add(rn);
     }
 
-    private static class Listening {
-        public Listening(Class<?> listensFor, EventListener listener) {
-            this.listensFor = listensFor;
-            this.listener = listener;
-        }
-
-        public final Class<?> listensFor;
-        public final EventListener listener;
-    }
-
     // Exceptions
 
+    /**
+     * Exception that is thrown if an event is raised during the handling of another event in the same thread.
+     */
     public static class RaiseAlreadyActive extends RuntimeException {
         private static final long serialVersionUID = 7713141366627046771L;
     }
 
+    /**
+     * Exception that is thrown if `EventDispatcher().afterwards()` is called while no event is handled in that thread.
+     */
     public static class RaiseNotActive extends RuntimeException {
         private static final long serialVersionUID = 2178481422042432110L;
     }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/event/EventHandler.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/event/EventHandler.java
@@ -1,0 +1,48 @@
+package de.unistuttgart.informatik.fius.icge.event;
+
+import java.util.ArrayList;
+
+public class EventHandler {
+    private final ArrayList<Listening> _listenings = new ArrayList<>();
+
+    public EventHandler() {
+        EventDispatcher.registerHandler(this);
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        EventDispatcher.deregisterHandler(this);
+    }
+
+    public EventListener addListener(Class<? extends Event> listensFor, EventListener listener) {
+        _listenings.add(new Listening(listensFor, listener));
+        return listener;
+    }
+
+    public boolean removeListener(EventListener listener) {
+        return _listenings.removeIf(entry -> entry.listener == listener);
+    }
+
+    void raise(Event e) {
+        for (Listening entry : new ArrayList<>(_listenings)) { // new list cause it might get modified concurrently
+            if (entry.listensFor.isAssignableFrom(e.getClass())) {
+                // we found an event listener that listens for this event
+                if (!entry.listener.handle(e)) {
+                    removeListener(entry.listener);
+                }
+            }
+        }
+    }
+
+    private static class Listening {
+        public Listening(Class<? extends Event> listensFor, EventListener listener) {
+            this.listensFor = listensFor;
+            this.listener = listener;
+        }
+
+        public final Class<?> listensFor;
+        public final EventListener listener;
+    }
+
+}

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Entity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Entity.java
@@ -11,6 +11,8 @@ import java.util.concurrent.Semaphore;
 import java.util.function.Predicate;
 
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
+import de.unistuttgart.informatik.fius.icge.event.EventHandler;
+import de.unistuttgart.informatik.fius.icge.event.EventListener;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation.SimulationEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation.TickEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.inspection.InspectionAttribute;
@@ -519,7 +521,9 @@ public abstract class Entity {
             int thisMoveTick = this._blockedUntilTick;
             if (this.simulation().tickCount() < thisMoveTick) {
                 Semaphore sem = new Semaphore(0);
-                EventDispatcher.addListener(TickEvent.class, ev -> {
+                // we have this `handler` variable such that the handler doesn't get garbage collected
+                EventHandler handler = new EventHandler();
+                handler.addListener(TickEvent.class, ev -> {
                     TickEvent te = (TickEvent) ev;
                     if ((te.simulation == this.simulation()) && (te.tickCount >= thisMoveTick)) {
                         sem.release();
@@ -527,7 +531,7 @@ public abstract class Entity {
                     }
                     return true;
                 });
-                sem.acquireUninterruptibly();
+                sem.acquireUninterruptibly(); // after this line, the `handler` may safely be garbage collected
             }
         }
         synchronized (this.simulation()) {

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/MovableEntity.java
@@ -11,6 +11,8 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
+import de.unistuttgart.informatik.fius.icge.event.EventHandler;
+import de.unistuttgart.informatik.fius.icge.event.EventListener;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation.SimulationEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.inspection.InspectionMethod;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject;
@@ -22,6 +24,7 @@ import de.unistuttgart.informatik.fius.icge.territory.WorldObject.Direction;
 public abstract class MovableEntity extends Entity {
 
     private final Deque<MoveEvent> _positionStack = new ArrayDeque<>(100);
+    private final EventHandler _eventHandler = new EventHandler();
 
     /**
      * Creates a new movable entity in the given simulation
@@ -32,14 +35,14 @@ public abstract class MovableEntity extends Entity {
     protected MovableEntity(Simulation sim) {
         super(sim);
 
-        EventDispatcher.addListener(SpawnEvent.class, ev -> {
+        this._eventHandler.addListener(SpawnEvent.class, ev -> {
             SpawnEvent se = (SpawnEvent) ev;
             if ((se.simulation == this.simulation()) && (se.entity == this)) {
                 this._positionStack.add(new MoveEvent(this.simulation(), this, se.row, se.column));
             }
             return true;
         });
-        EventDispatcher.addListener(MoveEvent.class, ev -> {
+        this._eventHandler.addListener(MoveEvent.class, ev -> {
             MoveEvent me = (MoveEvent) ev;
             if ((me.simulation == this.simulation()) && (me.entity == this)) {
                 this._positionStack.add(me);

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/Workbench.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/Workbench.java
@@ -9,11 +9,21 @@ package de.unistuttgart.informatik.fius.icge.workbench;
 
 import de.unistuttgart.informatik.fius.icge.event.Event;
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
-import de.unistuttgart.informatik.fius.icge.simulation.Entity.*;
+import de.unistuttgart.informatik.fius.icge.event.EventHandler;
+import de.unistuttgart.informatik.fius.icge.event.EventListener;
+import de.unistuttgart.informatik.fius.icge.simulation.Entity.DespawnEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Entity.EntityEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Entity.MessageEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Entity.SpawnEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Entity.TeleportEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.MovableEntity.MoveEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.MovableEntity.TurnLeftEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
-import de.unistuttgart.informatik.fius.icge.simulation.Simulation.*;
+import de.unistuttgart.informatik.fius.icge.simulation.Simulation.PauseEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Simulation.ResumeEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Simulation.SetTerritoryEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Simulation.SimulationEvent;
+import de.unistuttgart.informatik.fius.icge.simulation.Simulation.TickEvent;
 import de.unistuttgart.informatik.fius.icge.territory.WorldObject;
 import de.unistuttgart.informatik.fius.icge.workbench.swing.SwingView;
 
@@ -21,12 +31,13 @@ public class Workbench {
     
     private final String _name;
     private final WorkbenchView _view;
-    
+    private EventHandler _eventHandler = new EventHandler();
+
     public Workbench(String name) {
         this._name = name;
         this._view = new SwingView(name);
-        
-        EventDispatcher.addListener(SimulationEvent.class, this::handle);
+
+        this._eventHandler.addListener(SimulationEvent.class, this::handle);
     }
     
     public boolean opened() {

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/EntityInspector.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/EntityInspector.java
@@ -37,6 +37,7 @@ import javax.swing.WindowConstants;
 
 import de.unistuttgart.informatik.fius.icge.Engine;
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
+import de.unistuttgart.informatik.fius.icge.event.EventHandler;
 import de.unistuttgart.informatik.fius.icge.event.EventListener;
 import de.unistuttgart.informatik.fius.icge.simulation.Entity;
 import de.unistuttgart.informatik.fius.icge.simulation.Entity.DespawnEvent;
@@ -68,6 +69,8 @@ public class EntityInspector {
 
     private List<String> _methodList;
     private Map<String, JTextArea> _methodToLabel;
+
+    private EventHandler _eventHandler = new EventHandler();
 
     /**
      * Create new entity inspector which chooses from all available entities
@@ -149,7 +152,7 @@ public class EntityInspector {
         this.setEntity(this._entities.get(0));
 
         // listener for entity events which updates the inspected values
-        EventListener listener = EventDispatcher.addListener(EntityEvent.class, ev -> {
+        this._eventHandler.addListener(EntityEvent.class, ev -> {
             EntityEvent eev = (EntityEvent) ev;
             if (this._selectedEntity == eev.entity) {
                 if (eev instanceof DespawnEvent) {
@@ -159,14 +162,6 @@ public class EntityInspector {
                 }
             }
             return true;
-        });
-
-        // remove listener when the inspector is closed
-        this._frame.addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                EventDispatcher.removeListener(listener);
-            }
         });
 
     }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/ToolBar.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/swing/ToolBar.java
@@ -16,6 +16,8 @@ import javax.swing.JSlider;
 import javax.swing.JToolBar;
 
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
+import de.unistuttgart.informatik.fius.icge.event.EventHandler;
+import de.unistuttgart.informatik.fius.icge.event.EventListener;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
 import de.unistuttgart.informatik.fius.icge.workbench.Workbench.SetSimulationEvent;
 import de.unistuttgart.informatik.fius.icge.workbench.WorkbenchView;
@@ -28,6 +30,7 @@ public class ToolBar extends JToolBar {
     private final WorkbenchView _view;
     private final JComboBox<String> _dropDown = new JComboBox<>();
     private final ArrayList<Runnable> _dropDownActions = new ArrayList<>();
+    private EventHandler _eventHandler = new EventHandler();
 
     public ToolBar(SwingView view, ToolHandler toolHandler) {
         this._view = view;
@@ -99,7 +102,7 @@ public class ToolBar extends JToolBar {
             }
         });
 
-        EventDispatcher.addListener(SetSimulationEvent.class, ev -> {
+        this._eventHandler.addListener(SetSimulationEvent.class, ev -> {
             if (this._view == ((SetSimulationEvent) ev).view) {
                 updater.run();
             }

--- a/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/tools/SimulationController.java
+++ b/src/main/java/de/unistuttgart/informatik/fius/icge/workbench/tools/SimulationController.java
@@ -17,6 +17,7 @@ import javax.swing.JButton;
 
 import de.unistuttgart.informatik.fius.icge.event.Event;
 import de.unistuttgart.informatik.fius.icge.event.EventDispatcher;
+import de.unistuttgart.informatik.fius.icge.event.EventHandler;
 import de.unistuttgart.informatik.fius.icge.simulation.Entity.EntityEvent;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation.PauseEvent;
@@ -39,6 +40,8 @@ public class SimulationController {
 
     private final Image _playImage;
     private final Image _pauseImage;
+
+    private EventHandler _eventHandler = new EventHandler();
 
     /**
      * Creates a tool handler.
@@ -66,10 +69,10 @@ public class SimulationController {
 
         this.updatePlayButton(false);
 
-        EventDispatcher.addListener(SetSimulationEvent.class, this::handleSetSimulation);
-        EventDispatcher.addListener(EntityEvent.class, this::handleEntityEvent);
-        EventDispatcher.addListener(PauseEvent.class, this::handlePause);
-        EventDispatcher.addListener(ResumeEvent.class, this::handleResume);
+        this._eventHandler.addListener(SetSimulationEvent.class, this::handleSetSimulation);
+        this._eventHandler.addListener(EntityEvent.class, this::handleEntityEvent);
+        this._eventHandler.addListener(PauseEvent.class, this::handlePause);
+        this._eventHandler.addListener(ResumeEvent.class, this::handleResume);
     }
 
     public JButton playButton() {


### PR DESCRIPTION
## TL;DR

`Event`s are now handled by adding an `EventListener` to an `EventHandler` which gets
registered to the `EventDispatcher`. The `EventHandler`s are only weakly referenced inside
the `EventDispatcher`.

# What changed

Previously events were handled by registering an `EventListener` to the `EventDispatcher`.
Now events are handled by creating an `EventHandler`, registering that `EventHandler` to the
`EventDispatcher` and then registering an `EventListener` to the `EventHandler`.
`EventDispatcher` is still a singleton. There can be arbitrarily man `EventHandler`s added
to the `EventDispatcher` and arbitrarily many `EventListener`s added to one `EventHandler`.

## The important thing:

`EventHandler`s are only weakly-referenced by the `EventDispatcher`. The code that registers
them have to keep a reference to the `EventHandler` in order to prevent them from being
garbage collected.

## Why:

`EventListener`s often keep references to objects. That way, if the `EventListener` isn't
eventually removed from the `EventDispatcher` it stays alive forever together with all of
the objects if references directly or indirectly, thus leaking memory. (Leaking memory here
means that memory isn't freed even though it's not _needed_ anymore. This differs from the
C-meaning of a memory leak where the memory can't be referenced anymore. The memory can
still theoretically be referenced, but isn't by the program.)

Now the calling code can (and must keep a reference to the `EventHandler` inside some object
to which that `EventHandler` is meaningfully associated. If that object gets garbage
collected, there won't be any strong reference to the `EventHandler` anymore (since it's
only weakly referenced by the `EventDispatcher`, using a `WeakReference<EventHandler>`) and
the `EventHandler` will therefore be garbage collected as well.